### PR TITLE
Be aware of func literals in addition to func declarations.

### DIFF
--- a/returns/fix.go
+++ b/returns/fix.go
@@ -28,6 +28,8 @@ func fixReturns(fset *token.FileSet, f *ast.File) error {
 		switch v := node.(type) {
 		case *ast.FuncDecl:
 			inFunc = v.Type
+		case *ast.FuncLit:
+			inFunc = v.Type
 		case *ast.ReturnStmt:
 			incReturns[v] = inFunc
 		}

--- a/returns/fix_test.go
+++ b/returns/fix_test.go
@@ -251,10 +251,21 @@ func F() (int, error) { return 7, errors.New("foo") }
 `,
 	},
 
+	// Preserve returns in closures when correct number of values.
+	{
+		name: "closures with valid-arity returns",
+		in: `package foo
+func F() (int, error) { _ = func() string { return "foo" } }
+`,
+		out: `package foo
+
+func F() (int, error) { _ = func() string { return "foo" } }
+`,
+	},
+
 	// Process returns in closures (not just top-level func decls).
 	{
 		name: "closures",
-		skip: true,
 		in: `package foo
 func main() { _ = func() (int, error) { return errors.New("foo") } }
 `,


### PR DESCRIPTION
Fixes #2.
Add test case for preserving returns in closures when correct number of values.
Enable test case for processing returns in closures (not just top-level func decls).
