### PR TITLE
Remove dependencies on deprecated x/tools

### DIFF
--- a/goreturns.go
+++ b/goreturns.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	_ "go/importer"
 	"go/scanner"
 	"io"
 	"io/ioutil"
@@ -17,7 +18,6 @@ import (
 	"runtime"
 	"strings"
 
-	_ "golang.org/x/tools/go/gcimporter"
 	"golang.org/x/tools/imports"
 
 	"sourcegraph.com/sqs/goreturns/returns"

--- a/returns/fix.go
+++ b/returns/fix.go
@@ -9,9 +9,8 @@ import (
 	"go/ast"
 	"go/printer"
 	"go/token"
+	"go/types"
 	"os"
-
-	"golang.org/x/tools/go/types"
 )
 
 func fixReturns(fset *token.FileSet, f *ast.File, typeInfo *types.Info) error {

--- a/returns/fix_test.go
+++ b/returns/fix_test.go
@@ -6,9 +6,8 @@ package returns
 
 import (
 	"flag"
+	_ "go/importer"
 	"testing"
-
-	_ "golang.org/x/tools/go/gcimporter"
 )
 
 var only = flag.String("only", "", "If non-empty, the fix test to run")

--- a/returns/index.go
+++ b/returns/index.go
@@ -2,8 +2,7 @@ package returns
 
 import (
 	"go/ast"
-
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 // funcHasSingleReturnVal returns true if func called by e has a

--- a/returns/returns.go
+++ b/returns/returns.go
@@ -16,11 +16,10 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/tools/go/types"
 )
 
 // Options specifies options for processing files.


### PR DESCRIPTION
Update dependencies per
https://groups.google.com/forum/#!topic/golang-announce/qu_rAphYdxY.

Note that this causes `goreturns` to only build on
Go 1.5+.  To support building on Go1.4 likely would require
copying in the previous x/tools sources that are needed.

Fixes #19.