### PR TITLE
Remove bare returns

### DIFF
--- a/_samples/b.go
+++ b/_samples/b.go
@@ -1,0 +1,8 @@
+package foo
+
+import "errors"
+
+func Fb() (res int, err error) {
+	err = errors.New("foo")
+	return
+}

--- a/goreturns.go
+++ b/goreturns.go
@@ -38,6 +38,7 @@ var (
 func init() {
 	flag.BoolVar(&options.PrintErrors, "p", false, "print non-fatal typechecking errors to stderr")
 	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
+	flag.BoolVar(&options.RemoveBareReturns, "b", false, "remove bare returns")
 }
 
 func report(err error) {

--- a/returns/returns.go
+++ b/returns/returns.go
@@ -29,6 +29,8 @@ type Options struct {
 	PrintErrors bool // Print non-fatal typechecking errors to stderr (interferes with some tools that use gofmt/goimports and expect them to only print code or diffs to stdout + stderr)
 
 	AllErrors bool // Report all errors (not just the first 10 on different lines)
+
+	RemoveBareReturns bool // Remove bare returns
 }
 
 // Process formats and adjusts returns for the provided file in a
@@ -48,6 +50,12 @@ func Process(pkgDir, filename string, src []byte, opt *Options) ([]byte, error) 
 
 	if err := fixReturns(fileSet, file, typeInfo); err != nil {
 		return nil, err
+	}
+
+	if opt.RemoveBareReturns {
+		if err := removeBareReturns(fileSet, file, typeInfo); err != nil {
+			return nil, err
+		}
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
It converts

```
func Fb() (res int, err error) {
	err = errors.New("foo")
	return
}
```

into

```
func Fb() (res int, err error) {
	err = errors.New("foo")
	return res, err
}
```