### PR TITLE
Support goimports -local flag

### DIFF
--- a/goreturns.go
+++ b/goreturns.go
@@ -39,6 +39,12 @@ func init() {
 	flag.BoolVar(&options.PrintErrors, "p", false, "print non-fatal typechecking errors to stderr")
 	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
 	flag.BoolVar(&options.RemoveBareReturns, "b", false, "remove bare returns")
+	flag.StringVar(
+		&imports.LocalPrefix,
+		"local",
+		"",
+		"put imports beginning with this string after 3rd-party packages (see goimports)",
+	)
 }
 
 func report(err error) {


### PR DESCRIPTION
See: https://godoc.org/golang.org/x/tools/imports#pkg-variables
Changes to `goimports`: https://github.com/golang/tools/commit/ed69e84b1518b5857a9f4e01d1f9cefdcc45246e

This is useful. `goreturns` needs this flag to keep itself as a replacement for `goimports`.