### PR TITLE
Add default importer to types.Config to fix goreturns for Go 1.9

### DIFF
--- a/returns/returns.go
+++ b/returns/returns.go
@@ -13,6 +13,7 @@ import (
 	"go/ast"
 	"go/build"
 	"go/format"
+	"go/importer"
 	"go/parser"
 	"go/printer"
 	"go/token"
@@ -120,6 +121,7 @@ func parseAndCheck(fset *token.FileSet, pkgDir, filename string, src []byte, opt
 			}
 			nerrs++
 		},
+		Importer: importer.Default(),
 	}
 
 	info := &types.Info{


### PR DESCRIPTION
Currently goreturns seems to be broken on Go 1.9 because type checking fails. It successfully completes but never changes anything. The problem is types.Check fails with "could not import x (Config.Importer not installed)". Most of the test cases in fix_test.go also fail. 

Adding the default importer to types.Config fixes this and all tests pass. Should fix #35.