### PR TITLE
Support disable formatting + fix some tests

### DIFF
--- a/goreturns.go
+++ b/goreturns.go
@@ -40,6 +40,7 @@ func init() {
 	flag.BoolVar(&options.PrintErrors, "p", false, "print non-fatal typechecking errors to stderr")
 	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
 	flag.BoolVar(&options.RemoveBareReturns, "b", false, "remove bare returns")
+	flag.BoolVar(&options.Format, "f", false, "format source")
 	flag.StringVar(
 		&imports.LocalPrefix,
 		"local",

--- a/returns/fix_test.go
+++ b/returns/fix_test.go
@@ -243,17 +243,16 @@ func F() ([2]int, error) { return [2]int{}, errors.New("foo") }
 	// Synthesize zero values for structs in same package.
 	{
 		name: "structs",
-		skip: true,
 		in: `package foo
 import "errors"
-type T struct {}
+type T struct{}
 func F() (T, error) { return errors.New("foo") }
 `,
 		out: `package foo
 
 import "errors"
 
-type T struct {}
+type T struct{}
 
 func F() (T, error) { return T{}, errors.New("foo") }
 `,
@@ -307,17 +306,16 @@ func F() (url2.URL, error) { return url2.URL{}, errors.New("foo") }
 	// Synthesize zero values (nil) for interface types.
 	{
 		name: "interfaces",
-		skip: true,
 		in: `package foo
 import "errors"
-type I interface {}
+type I interface{}
 func F() (I, error) { return errors.New("foo") }
 `,
 		out: `package foo
 
 import "errors"
 
-type I interface {}
+type I interface{}
 
 func F() (I, error) { return nil, errors.New("foo") }
 `,
@@ -327,7 +325,6 @@ func F() (I, error) { return nil, errors.New("foo") }
 	// packages.
 	{
 		name: "external interfaces",
-		skip: true,
 		in: `package foo
 import (
 	"errors"
@@ -430,7 +427,7 @@ func outer() (string, error) {
 }
 
 func TestFixReturns(t *testing.T) {
-	options := &Options{Fragment: true}
+	options := &Options{Fragment: true, Format: true}
 
 	for _, tt := range tests {
 		if *only != "" && tt.name != *only {
@@ -447,5 +444,14 @@ func TestFixReturns(t *testing.T) {
 		if got := string(buf); got != tt.out {
 			t.Errorf("results diff on %q\nGOT:\n%s\nWANT:\n%s\n", tt.name, got, tt.out)
 		}
+	}
+}
+
+func BenchmarkFixReturns(b *testing.B) {
+	options := &Options{Fragment: true}
+
+	tt := tests[1]
+	for i := 0; i < b.N; i++ {
+		Process("", tt.name+".go", []byte(tt.in), options)
 	}
 }

--- a/returns/returns.go
+++ b/returns/returns.go
@@ -32,6 +32,8 @@ type Options struct {
 	AllErrors bool // Report all errors (not just the first 10 on different lines)
 
 	RemoveBareReturns bool // Remove bare returns
+
+	Format bool // Format source after inserting returns
 }
 
 // Process formats and adjusts returns for the provided file in a
@@ -69,9 +71,11 @@ func Process(pkgDir, filename string, src []byte, opt *Options) ([]byte, error) 
 		out = adjust(src, out)
 	}
 
-	out, err = format.Source(out)
-	if err != nil {
-		return nil, err
+	if opt.Format {
+		out, err = format.Source(out)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return out, nil
 }


### PR DESCRIPTION
I've added -f flag to disable format because many editors have already built-in support for gofmt.

- fix few tests + hack for returning nil for imported interfaces.