### PR TITLE
Read default values of all flags from ~/.goreturns.json file

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"golang.org/x/tools/imports"
+)
+
+type Config struct {
+	// Accept fragment of a source file (no package statement)
+	Fragment *bool `json:"fragment,omitempty"`
+
+	// Print non-fatal typechecking errors to stderr (interferes with some tools that use gofmt/goimports and expect them to only print code or diffs to stdout + stderr)
+	PrintErrors *bool `json:"printErrors,omitempty"`
+
+	// Report all errors (not just the first 10 on different lines)
+	AllErrors *bool `json:"allErrors,omitempty"`
+
+	// Remove bare returns
+	RemoveBareReturns *bool `json:"removeBareReturns,omitempty"`
+
+	// put imports beginning with this string after 3rd-party packages (see goimports)
+	Local string `json:"local,omitempty"`
+}
+
+func loadConfigFile() error {
+	userObj, err := user.Current()
+	if err != nil {
+		return err
+	}
+	fpath := filepath.Join(userObj.HomeDir, ".goreturns.json")
+	jsonBytes, err := ioutil.ReadFile(fpath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	c := &Config{}
+	err = json.Unmarshal(jsonBytes, c)
+	if err != nil {
+		return err
+	}
+	if c.Fragment != nil {
+		options.Fragment = *c.Fragment
+	}
+	if c.PrintErrors != nil {
+		options.PrintErrors = *c.PrintErrors
+	}
+	if c.AllErrors != nil {
+		options.AllErrors = *c.AllErrors
+	}
+	if c.RemoveBareReturns != nil {
+		options.RemoveBareReturns = *c.RemoveBareReturns
+	}
+	if c.Local != "" {
+		imports.LocalPrefix = c.Local
+	}
+	return nil
+}

--- a/goreturns.go
+++ b/goreturns.go
@@ -37,13 +37,34 @@ var (
 )
 
 func init() {
-	flag.BoolVar(&options.PrintErrors, "p", false, "print non-fatal typechecking errors to stderr")
-	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
-	flag.BoolVar(&options.RemoveBareReturns, "b", false, "remove bare returns")
+	{
+		err := loadConfigFile()
+		if err != nil {
+			panic(err)
+		}
+	}
+	flag.BoolVar(
+		&options.PrintErrors,
+		"p",
+		options.PrintErrors,
+		"print non-fatal typechecking errors to stderr",
+	)
+	flag.BoolVar(
+		&options.AllErrors,
+		"e",
+		options.AllErrors,
+		"report all errors (not just the first 10 on different lines)",
+	)
+	flag.BoolVar(
+		&options.RemoveBareReturns,
+		"b",
+		options.RemoveBareReturns,
+		"remove bare returns",
+	)
 	flag.StringVar(
 		&imports.LocalPrefix,
 		"local",
-		"",
+		imports.LocalPrefix,
 		"put imports beginning with this string after 3rd-party packages (see goimports)",
 	)
 }


### PR DESCRIPTION
Since vscode does not accept custom command / flags for `goreturns`, this seems the best way to add flags (for example `-local` in our case).
Create a `~/.goreturns.json` file with this template:

```
{
	"fragment": false,
	"printErrors": false,
	"allErrors": false,
	"removeBareReturns": false,
	"local": ""
}
```

Passing flags will override these values.